### PR TITLE
Fix UUIDField max_length Argument Error in Edgy ORM

### DIFF
--- a/docs_src/models/pk_with_default.py
+++ b/docs_src/models/pk_with_default.py
@@ -8,7 +8,7 @@ models = Registry(database=database)
 
 
 class User(edgy.Model):
-    id: int = edgy.UUIDField(max_length=255, primary_key=True, default=uuid.uuid4)
+    id:str = edgy.UUIDField(primary_key=True, default=uuid.uuid4)
     age: int = edgy.IntegerField(minimum=18)
     is_active: bool = edgy.BooleanField(default=True)
 


### PR DESCRIPTION
In the current implementation of the Edgy ORM, the UUIDField throws(TypeError: object of type 'asyncpg.pgproto.pgproto.UUID' has no len()) error when the max_length argument is included. Upon investigation, it was found that the UUIDField does not accept a max_length parameter, which is causing the issue.

To resolve this, I have removed the max_length argument from the UUIDField in the User model.

This pull request contains the necessary changes to fix the issue. Please review and provide feedback.